### PR TITLE
Add detection test for Face.jpeg

### DIFF
--- a/test_face_swap.py
+++ b/test_face_swap.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 """Test script to debug face swapping issues."""
 
-import sys
 import cv2
-import numpy as np
+from pathlib import Path
 from modules.core import FaceSwapper
 
 def test_face_swap():
@@ -24,8 +23,17 @@ def test_face_swap():
     # Test face detection
     print("\n2. Testing face detection...")
     
-    # Create a simple test image (you can replace with actual image path)
-    test_image = np.ones((480, 640, 3), dtype=np.uint8) * 255
+    # Load the provided Face.jpeg for detection
+    image_path = Path(__file__).resolve().parent / "tests" / "Face.jpeg"
+    if not image_path.exists():
+        raise FileNotFoundError(
+            f"Test image not found at {image_path}. "
+            "Place a Face.jpeg image in the tests directory."
+        )
+
+    test_image = cv2.imread(str(image_path))
+    if test_image is None:
+        raise RuntimeError(f"Failed to read image at {image_path}")
     
     try:
         faces = face_swapper.face_app.get(test_image)

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -1,0 +1,18 @@
+import unittest
+from pathlib import Path
+import cv2
+from modules.core import FaceSwapper
+
+class FaceDetectionTest(unittest.TestCase):
+    def test_face_jpeg_contains_face(self):
+        img_path = Path(__file__).resolve().parent / "Face.jpeg"
+        if not img_path.exists():
+            self.skipTest(f"Test image not found at {img_path}")
+        swapper = FaceSwapper(execution_provider='cpu')
+        img = cv2.imread(str(img_path))
+        self.assertIsNotNone(img, f"Failed to read image at {img_path}")
+        faces = swapper.face_app.get(img)
+        self.assertGreater(len(faces), 0, "No faces detected in Face.jpeg")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- update `test_face_swap.py` to load `tests/Face.jpeg`
- add `tests/test_face_detection.py` with a unittest to verify a face can be detected in `Face.jpeg`

## Testing
- `python3 -m unittest discover -v` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_b_684912134694832a9eeb6400d496228b