### PR TITLE
Improve diagnostic output for face detection

### DIFF
--- a/test_face_swap.py
+++ b/test_face_swap.py
@@ -4,6 +4,8 @@
 import cv2
 from pathlib import Path
 from modules.core import FaceSwapper
+import insightface
+import onnxruntime as ort
 
 def test_face_swap():
     print("=== Face Swap Test ===\n")
@@ -11,6 +13,10 @@ def test_face_swap():
     # Initialize face swapper
     print("1. Initializing face swapper...")
     face_swapper = FaceSwapper(execution_provider='cpu')  # Use CPU for testing
+    print("Providers in use:", face_swapper.providers)
+    print("Available ORT providers:", ort.get_available_providers())
+    print("InsightFace version:", insightface.__version__)
+    print("Face analysis model root:", face_swapper.face_app.root)
     
     # Check if model is loaded
     if face_swapper.face_swapper is None:
@@ -34,10 +40,14 @@ def test_face_swap():
     test_image = cv2.imread(str(image_path))
     if test_image is None:
         raise RuntimeError(f"Failed to read image at {image_path}")
+    print("Image shape:", test_image.shape)
+    print("Image dtype:", test_image.dtype)
     
     try:
         faces = face_swapper.face_app.get(test_image)
         print(f"✅ Face detection working. Found {len(faces)} faces.")
+        for i, f in enumerate(faces):
+            print(f"Face {i}: bbox={f.bbox}, score={f.det_score}")
     except Exception as e:
         print(f"❌ Face detection error: {e}")
         return False

--- a/tests/test_face_detection.py
+++ b/tests/test_face_detection.py
@@ -2,6 +2,8 @@ import unittest
 from pathlib import Path
 import cv2
 from modules.core import FaceSwapper
+import insightface
+import onnxruntime as ort
 
 class FaceDetectionTest(unittest.TestCase):
     def test_face_jpeg_contains_face(self):
@@ -9,9 +11,20 @@ class FaceDetectionTest(unittest.TestCase):
         if not img_path.exists():
             self.skipTest(f"Test image not found at {img_path}")
         swapper = FaceSwapper(execution_provider='cpu')
+        print("Providers in use:", swapper.providers)
+        print("Available ORT providers:", ort.get_available_providers())
+        print("InsightFace version:", insightface.__version__)
+        print("Face analysis model root:", swapper.face_app.root)
+
         img = cv2.imread(str(img_path))
         self.assertIsNotNone(img, f"Failed to read image at {img_path}")
+        print("Image shape:", img.shape)
+        print("Image dtype:", img.dtype)
+
         faces = swapper.face_app.get(img)
+        print(f"Detected {len(faces)} faces")
+        for i, f in enumerate(faces):
+            print(f"Face {i}: bbox={f.bbox}, score={f.det_score}")
         self.assertGreater(len(faces), 0, "No faces detected in Face.jpeg")
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- add detailed diagnostic prints in `test_face_swap.py`
- extend `tests/test_face_detection.py` with similar debugging info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_b_684926cad99c832a9df403ee21e6819d