### PR TITLE
Fix os import issue in test script

### DIFF
--- a/test_face_swap.py
+++ b/test_face_swap.py
@@ -70,7 +70,6 @@ def test_face_swap():
         return False
     
     print("\n3. Checking InsightFace models...")
-    import os
     insightface_path = os.path.expanduser("~/.insightface/models")
     if os.path.exists(insightface_path):
         print(f"InsightFace models directory: {insightface_path}")


### PR DESCRIPTION
## Summary
- remove redundant import that shadowed module `os`

## Testing
- `python3 -m py_compile test_face_swap.py`
- `python3 -m unittest tests/test_face_detection.py` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_b_684932040d88832a970b376f118405eb